### PR TITLE
Conceal

### DIFF
--- a/action.php
+++ b/action.php
@@ -12,6 +12,8 @@ class action_plugin_xtern extends DokuWiki_Action_Plugin {
        $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handle_ajax_call_unknown');    
        $controller->register_hook('DOKUWIKI_STARTED', 'BEFORE', $this, 'curl_check'); 
        $controller->register_hook('IO_WIKIPAGE_READ', 'AFTER', $this, 'handle_wiki_read'); 	
+       $controller->register_hook('TPL_CONTENT_DISPLAY', 'BEFORE', $this, 'handle_wiki_content'); 	
+       
     }
 
     /**
@@ -78,6 +80,7 @@ class action_plugin_xtern extends DokuWiki_Action_Plugin {
         foreach($ar[$id] as $url) {            
            $this->update_wiki_page($event->result, $url) ;
         }
+		
 		$srch = array('[[__ BROKEN-LINK:','LINK-BROKEN __ LINK-BROKEN __') ;
 		$repl = array( '[[','LINK-BROKEN __');
 		$event->result = str_replace($srch,$repl,	$event->result);
@@ -93,7 +96,6 @@ class action_plugin_xtern extends DokuWiki_Action_Plugin {
                       "|(?<!LINK:)\s*(\[\[)?(". preg_quote($url). "(\|)*([^\]]+)*(\]\])?)[\s]*|ms",
                      function($matches){
                        $test = preg_split("/[\s]+/",$matches[2]);                      
-                			    							
 							foreach($test as $piece) {
 								if(strpos($piece,'http') !== false) {
                                     if(strpos($piece, $this->current) !== false && strpos($matches[0],'-LINK:' .$piece) === false) {   
@@ -114,5 +116,11 @@ class action_plugin_xtern extends DokuWiki_Action_Plugin {
                   $result
                 );
     }
+    
+  function handle_wiki_content(Doku_Event $event, $param) {  
+     global $ACT;
+	 if($ACT == 'preview') return;
+     $event->data = preg_replace('#\<em\s+class=(\"|\')u(\1)\>\s*BROKEN\-LINK\:(.*?)LINK\-BROKEN\s*</em>#',"$3",$event->data);
+   }
 
  }

--- a/action.php
+++ b/action.php
@@ -119,8 +119,13 @@ class action_plugin_xtern extends DokuWiki_Action_Plugin {
     
   function handle_wiki_content(Doku_Event $event, $param) {  
      global $ACT;
-	 if($ACT == 'preview') return;
+     
+	 if($ACT == 'preview') {
+         return;
+     }
+     else if($this->getConf('conceal')) {
      $event->data = preg_replace('#\<em\s+class=(\"|\')u(\1)\>\s*BROKEN\-LINK\:(.*?)LINK\-BROKEN\s*</em>#',"$3",$event->data);
+     }
    }
 
  }

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,3 +1,5 @@
 <?php
 $conf['ca_required'] = 0;
 $conf['max_time'] = 120;
+$conf['conceal'] = 1;
+

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,3 +1,5 @@
 <?php
 $meta['ca_required'] = array('onoff');
 $meta['max_time'] = array('numeric');
+$meta['conceal']  = array('onoff');
+

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,3 +1,4 @@
 <?php
 $lang['ca_required'] = 'This wiki uses a cacerts.pem file installed in the <code>xtern/ca</code> directory.';
 $lang['max_time'] = 'Time in seconds to allow for broken link checking in the admin panel.  Defaults to 120';
+$lang['conceal'] = 'Display <code>BROKEN-LINK</code> markup in preview mode only; hide it for general viewing of pages.';


### PR DESCRIPTION
Merge enables concealing of `BROKEN-LINK` markup for general viewing, displaying only in preview mode.